### PR TITLE
feat(games): add PM support for VoltorbFlip with private HTML

### DIFF
--- a/src/ElsaMina.Commands/CommandModule.cs
+++ b/src/ElsaMina.Commands/CommandModule.cs
@@ -234,6 +234,7 @@ public class CommandModule : Module
         builder.RegisterType<PokeCriesGame>().AsSelf();
         builder.RegisterType<GatekeepersGame>().AsSelf();
 
+        builder.RegisterType<VoltorbFlipGameManager>().As<IVoltorbFlipGameManager>().SingleInstance();
         builder.RegisterType<WatchlistService>().As<IWatchlistService>().SingleInstance();
         builder.RegisterType<NameColorsService>()
             .As<INameColorsService>()

--- a/src/ElsaMina.Commands/VoltorbFlip/EndVoltorbFlipCommand.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/EndVoltorbFlipCommand.cs
@@ -7,9 +7,49 @@ namespace ElsaMina.Commands.VoltorbFlip;
 [NamedCommand("vfend", Aliases = ["end-voltorbflip"])]
 public class EndVoltorbFlipCommand : Command
 {
+    private readonly IRoomsManager _roomsManager;
+    private readonly IVoltorbFlipGameManager _gameManager;
+
+    public EndVoltorbFlipCommand(IRoomsManager roomsManager, IVoltorbFlipGameManager gameManager)
+    {
+        _roomsManager = roomsManager;
+        _gameManager = gameManager;
+    }
+
     public override Rank RequiredRank => Rank.Voiced;
+    public override bool IsAllowedInPrivateMessage => true;
 
     public override async Task RunAsync(IContext context, CancellationToken cancellationToken = default)
+    {
+        if (context.IsPrivateMessage)
+        {
+            await HandlePrivateMessageAsync(context);
+            return;
+        }
+
+        await HandleRoomMessageAsync(context);
+    }
+
+    private async Task HandlePrivateMessageAsync(IContext context)
+    {
+        var roomId = context.Target?.Trim();
+        if (string.IsNullOrEmpty(roomId))
+        {
+            return;
+        }
+
+        var voltorbFlip = _gameManager.GetGame(roomId, context.Sender.UserId);
+        if (voltorbFlip == null)
+        {
+            context.ReplyLocalizedMessage("vf_game_no_game");
+            return;
+        }
+
+        await voltorbFlip.CancelAsync();
+        context.ReplyLocalizedMessage("vf_game_cancelled");
+    }
+
+    private async Task HandleRoomMessageAsync(IContext context)
     {
         if (context.Room?.Game is IVoltorbFlipGame voltorbFlip)
         {

--- a/src/ElsaMina.Commands/VoltorbFlip/FlipVoltorbFlipCommand.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/FlipVoltorbFlipCommand.cs
@@ -8,10 +8,12 @@ namespace ElsaMina.Commands.VoltorbFlip;
 public class FlipVoltorbFlipCommand : Command
 {
     private readonly IRoomsManager _roomsManager;
+    private readonly IVoltorbFlipGameManager _gameManager;
 
-    public FlipVoltorbFlipCommand(IRoomsManager roomsManager)
+    public FlipVoltorbFlipCommand(IRoomsManager roomsManager, IVoltorbFlipGameManager gameManager)
     {
         _roomsManager = roomsManager;
+        _gameManager = gameManager;
     }
 
     public override bool IsPrivateMessageOnly => true;
@@ -36,9 +38,15 @@ public class FlipVoltorbFlipCommand : Command
             return;
         }
 
-        var room = _roomsManager.GetRoom(roomId);
-        if (room?.Game is IVoltorbFlipGame voltorbFlip)
+        var voltorbFlip = _gameManager.GetGame(roomId, context.Sender.UserId)
+            ?? _roomsManager.GetRoom(roomId)?.Game as IVoltorbFlipGame;
+
+        if (voltorbFlip != null)
         {
+            if (voltorbFlip.IsPrivateMode)
+            {
+                voltorbFlip.Context = context;
+            }
             await voltorbFlip.FlipTile(context.Sender, row, col);
         }
     }

--- a/src/ElsaMina.Commands/VoltorbFlip/IVoltorbFlipGame.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/IVoltorbFlipGame.cs
@@ -18,6 +18,9 @@ public interface IVoltorbFlipGame : IGame
     bool IsEnded { get; }
     bool IsMarkingMode { get; }
     bool[,] IsMarked { get; }
+    bool IsPrivateMode { get; }
+    string TargetRoomId { get; }
+    string TargetUserId { get; }
     IContext Context { get; set; }
     IUser Owner { get; set; }
 

--- a/src/ElsaMina.Commands/VoltorbFlip/IVoltorbFlipGameManager.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/IVoltorbFlipGameManager.cs
@@ -1,0 +1,8 @@
+namespace ElsaMina.Commands.VoltorbFlip;
+
+public interface IVoltorbFlipGameManager
+{
+    IVoltorbFlipGame GetGame(string roomId, string userId);
+    void RegisterGame(string roomId, string userId, IVoltorbFlipGame game);
+    void RemoveGame(string roomId, string userId);
+}

--- a/src/ElsaMina.Commands/VoltorbFlip/QuitVoltorbFlipCommand.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/QuitVoltorbFlipCommand.cs
@@ -8,10 +8,12 @@ namespace ElsaMina.Commands.VoltorbFlip;
 public class QuitVoltorbFlipCommand : Command
 {
     private readonly IRoomsManager _roomsManager;
+    private readonly IVoltorbFlipGameManager _gameManager;
 
-    public QuitVoltorbFlipCommand(IRoomsManager roomsManager)
+    public QuitVoltorbFlipCommand(IRoomsManager roomsManager, IVoltorbFlipGameManager gameManager)
     {
         _roomsManager = roomsManager;
+        _gameManager = gameManager;
     }
 
     public override bool IsPrivateMessageOnly => true;
@@ -20,9 +22,16 @@ public class QuitVoltorbFlipCommand : Command
     public override async Task RunAsync(IContext context, CancellationToken cancellationToken = default)
     {
         var roomId = context.Target.Trim();
-        var room = _roomsManager.GetRoom(roomId);
-        if (room?.Game is IVoltorbFlipGame voltorbFlip)
+
+        var voltorbFlip = _gameManager.GetGame(roomId, context.Sender.UserId)
+            ?? _roomsManager.GetRoom(roomId)?.Game as IVoltorbFlipGame;
+
+        if (voltorbFlip != null)
         {
+            if (voltorbFlip.IsPrivateMode)
+            {
+                voltorbFlip.Context = context;
+            }
             await voltorbFlip.QuitRound(context.Sender);
         }
     }

--- a/src/ElsaMina.Commands/VoltorbFlip/StartVoltorbFlipCommand.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/StartVoltorbFlipCommand.cs
@@ -9,15 +9,74 @@ namespace ElsaMina.Commands.VoltorbFlip;
 public class StartVoltorbFlipCommand : Command
 {
     private readonly IDependencyContainerService _dependencyContainerService;
+    private readonly IRoomsManager _roomsManager;
+    private readonly IVoltorbFlipGameManager _gameManager;
 
-    public StartVoltorbFlipCommand(IDependencyContainerService dependencyContainerService)
+    public StartVoltorbFlipCommand(IDependencyContainerService dependencyContainerService,
+        IRoomsManager roomsManager,
+        IVoltorbFlipGameManager gameManager)
     {
         _dependencyContainerService = dependencyContainerService;
+        _roomsManager = roomsManager;
+        _gameManager = gameManager;
     }
 
     public override Rank RequiredRank => Rank.Voiced;
+    public override bool IsAllowedInPrivateMessage => true;
 
     public override async Task RunAsync(IContext context, CancellationToken cancellationToken = default)
+    {
+        if (context.IsPrivateMessage)
+        {
+            await HandlePrivateMessageAsync(context);
+            return;
+        }
+
+        await HandleRoomMessageAsync(context);
+    }
+
+    private async Task HandlePrivateMessageAsync(IContext context)
+    {
+        var roomId = context.Target?.Trim();
+        if (string.IsNullOrEmpty(roomId))
+        {
+            context.ReplyLocalizedMessage("vf_game_pm_missing_room");
+            return;
+        }
+
+        var room = _roomsManager.GetRoom(roomId);
+        if (room == null)
+        {
+            context.ReplyLocalizedMessage("vf_game_pm_invalid_room");
+            return;
+        }
+
+        var userId = context.Sender.UserId;
+        var existingGame = _gameManager.GetGame(roomId, userId);
+        if (existingGame != null)
+        {
+            if (existingGame.IsRoundActive)
+            {
+                context.ReplyLocalizedMessage("vf_game_round_active");
+                return;
+            }
+
+            existingGame.Context = context;
+            await existingGame.StartNewRound();
+            return;
+        }
+
+        var game = _dependencyContainerService.Resolve<VoltorbFlipGame>();
+        game.Context = context;
+        game.Owner = context.Sender;
+        game.IsPrivateMode = true;
+        game.TargetRoomId = roomId;
+        game.TargetUserId = userId;
+        _gameManager.RegisterGame(roomId, userId, game);
+        await game.StartNewRound();
+    }
+
+    private async Task HandleRoomMessageAsync(IContext context)
     {
         var room = context.Room;
 

--- a/src/ElsaMina.Commands/VoltorbFlip/ToggleMarkVoltorbFlipCommand.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/ToggleMarkVoltorbFlipCommand.cs
@@ -8,10 +8,12 @@ namespace ElsaMina.Commands.VoltorbFlip;
 public class ToggleMarkVoltorbFlipCommand : Command
 {
     private readonly IRoomsManager _roomsManager;
+    private readonly IVoltorbFlipGameManager _gameManager;
 
-    public ToggleMarkVoltorbFlipCommand(IRoomsManager roomsManager)
+    public ToggleMarkVoltorbFlipCommand(IRoomsManager roomsManager, IVoltorbFlipGameManager gameManager)
     {
         _roomsManager = roomsManager;
+        _gameManager = gameManager;
     }
 
     public override bool IsPrivateMessageOnly => true;
@@ -20,9 +22,16 @@ public class ToggleMarkVoltorbFlipCommand : Command
     public override async Task RunAsync(IContext context, CancellationToken cancellationToken = default)
     {
         var roomId = context.Target.Trim();
-        var room = _roomsManager.GetRoom(roomId);
-        if (room?.Game is IVoltorbFlipGame voltorbFlip)
+
+        var voltorbFlip = _gameManager.GetGame(roomId, context.Sender.UserId)
+            ?? _roomsManager.GetRoom(roomId)?.Game as IVoltorbFlipGame;
+
+        if (voltorbFlip != null)
         {
+            if (voltorbFlip.IsPrivateMode)
+            {
+                voltorbFlip.Context = context;
+            }
             await voltorbFlip.ToggleMarkingMode(context.Sender);
         }
     }

--- a/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipBoard.cshtml
+++ b/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipBoard.cshtml
@@ -124,7 +124,7 @@
                             <button
                                 class="button"
                                 name="send"
-                                value="@(Model.Trigger)voltorbflip">
+                                value="@(Model.IsPrivateMode ? $"/botmsg {Model.BotName},{Model.Trigger}voltorbflip {Model.RoomId}" : $"{Model.Trigger}voltorbflip")">
                                 @GetString("vf_panel_new_round")
                             </button>
                             <br/><br/>
@@ -132,10 +132,20 @@
                         <button
                             class="button"
                             name="send"
-                            value="@(Model.Trigger)vfend">
+                            value="@(Model.IsPrivateMode ? $"/botmsg {Model.BotName},{Model.Trigger}vfend {Model.RoomId}" : $"{Model.Trigger}vfend")">
                             @GetString("vf_panel_stop")
                         </button>
                     </details>
+                }
+                else
+                {
+                    <br/>
+                    <button
+                        class="button"
+                        name="send"
+                        value="@(Model.IsPrivateMode ? $"/botmsg {Model.BotName},{Model.Trigger}voltorbflip {Model.RoomId}" : $"{Model.Trigger}voltorbflip")">
+                        @GetString("vf_panel_play_again")
+                    </button>
                 }
             </td>
         </tr>

--- a/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipGame.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipGame.cs
@@ -52,11 +52,15 @@ public class VoltorbFlipGame : Game, IVoltorbFlipGame
     public int[] ColSums { get; private set; }
     public int[] RowVoltorbs { get; private set; }
     public int[] ColVoltorbs { get; private set; }
+    public bool IsPrivateMode { get; set; }
+    public string TargetRoomId { get; set; }
+    public string TargetUserId { get; set; }
     public IContext Context { get; set; }
     public IUser Owner { get; set; }
     public bool IsMarkingMode { get; private set; }
     public bool[,] IsMarked { get; private set; }
-    private string GameIdentifier => $"vf-{Context.RoomId}-{_gameId}";
+    private string EffectiveRoomId => IsPrivateMode ? TargetRoomId : Context.RoomId;
+    private string GameIdentifier => $"vf-{EffectiveRoomId}-{_gameId}";
     private string AnnounceId => GameIdentifier;
 
     public async Task DisplayAnnounce()
@@ -68,11 +72,20 @@ public class VoltorbFlipGame : Game, IVoltorbFlipGame
                 CurrentGame = this,
                 BotName = _configuration.Name,
                 Trigger = _configuration.Trigger,
-                RoomId = Context.RoomId
+                RoomId = EffectiveRoomId,
+                IsPrivateMode = IsPrivateMode
             });
 
         _inactivityTimer.Restart();
-        Context.SendUpdatableHtml(AnnounceId, template.RemoveNewlines(), false);
+
+        if (IsPrivateMode)
+        {
+            Context.SendPrivateUpdatableHtml(TargetUserId, TargetRoomId, AnnounceId, template.RemoveNewlines(), false);
+        }
+        else
+        {
+            Context.SendUpdatableHtml(AnnounceId, template.RemoveNewlines(), false);
+        }
     }
 
     public async Task StartNewRound()
@@ -366,10 +379,18 @@ public class VoltorbFlipGame : Game, IVoltorbFlipGame
                 CurrentGame = this,
                 BotName = _configuration.Name,
                 Trigger = _configuration.Trigger,
-                RoomId = Context.RoomId,
-                ShowAll = showAll
+                RoomId = EffectiveRoomId,
+                ShowAll = showAll,
+                IsPrivateMode = IsPrivateMode
             });
 
-        Context.SendUpdatableHtml(GameIdentifier, template.RemoveNewlines(), !firstTime);
+        if (IsPrivateMode)
+        {
+            Context.SendPrivateUpdatableHtml(TargetUserId, TargetRoomId, GameIdentifier, template.RemoveNewlines(), !firstTime);
+        }
+        else
+        {
+            Context.SendUpdatableHtml(GameIdentifier, template.RemoveNewlines(), !firstTime);
+        }
     }
 }

--- a/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipGameManager.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipGameManager.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace ElsaMina.Commands.VoltorbFlip;
+
+public class VoltorbFlipGameManager : IVoltorbFlipGameManager
+{
+    private readonly ConcurrentDictionary<(string RoomId, string UserId), IVoltorbFlipGame> _games = new();
+
+    public IVoltorbFlipGame GetGame(string roomId, string userId)
+    {
+        _games.TryGetValue((roomId, userId), out var game);
+        return game;
+    }
+
+    public void RegisterGame(string roomId, string userId, IVoltorbFlipGame game)
+    {
+        var key = (roomId, userId);
+        _games[key] = game;
+        game.GameEnded += () => _games.TryRemove(key, out _);
+    }
+
+    public void RemoveGame(string roomId, string userId)
+    {
+        _games.TryRemove((roomId, userId), out _);
+    }
+}

--- a/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipModel.cs
+++ b/src/ElsaMina.Commands/VoltorbFlip/VoltorbFlipModel.cs
@@ -9,4 +9,5 @@ public class VoltorbFlipModel : LocalizableViewModel
     public required string BotName { get; init; }
     public required string RoomId { get; init; }
     public bool ShowAll { get; init; }
+    public bool IsPrivateMode { get; init; }
 }

--- a/src/ElsaMina.Core/Contexts/Context.cs
+++ b/src/ElsaMina.Core/Contexts/Context.cs
@@ -143,4 +143,5 @@ public abstract class Context : IContext
     public abstract void ReplyHtml(string html, string roomId = null, bool rankAware = false);
     public abstract void SendHtmlTo(string userId, string html, string roomId = null);
     public abstract void SendUpdatableHtml(string htmlId, string html, bool isChanging);
+    public abstract void SendPrivateUpdatableHtml(string userId, string roomId, string htmlId, string html, bool isChanging);
 }

--- a/src/ElsaMina.Core/Contexts/IContext.cs
+++ b/src/ElsaMina.Core/Contexts/IContext.cs
@@ -31,5 +31,6 @@ public interface IContext
     void ReplyHtml(string html, string roomId = null, bool rankAware = false);
     void SendHtmlTo(string userId, string html, string roomId = null);
     void SendUpdatableHtml(string htmlId, string html, bool isChanging);
+    void SendPrivateUpdatableHtml(string userId, string roomId, string htmlId, string html, bool isChanging);
     Task HandleErrorAsync(Exception exception, CancellationToken cancellationToken = default);
 }

--- a/src/ElsaMina.Core/Contexts/PmContext.cs
+++ b/src/ElsaMina.Core/Contexts/PmContext.cs
@@ -50,4 +50,10 @@ public class PmContext : Context
         var command = isChanging ? "pmchangeuhtml" : "pmuhtml";
         Bot.Say(RoomId, $"/{command} {Sender.UserId}, {htmlId}, {html}");
     }
+
+    public override void SendPrivateUpdatableHtml(string userId, string roomId, string htmlId, string html, bool isChanging)
+    {
+        var command = isChanging ? "changeprivateuhtml" : "sendprivateuhtml";
+        Bot.Say(roomId ?? RoomId, $"/{command} {userId}, {htmlId}, {html}");
+    }
 }

--- a/src/ElsaMina.Core/Contexts/RoomContext.cs
+++ b/src/ElsaMina.Core/Contexts/RoomContext.cs
@@ -86,4 +86,10 @@ public class RoomContext : Context
         var command = isChanging ? "changeuhtml" : "adduhtml";
         Bot.Say(RoomId, $"/{command} {htmlId}, {html}");
     }
+
+    public override void SendPrivateUpdatableHtml(string userId, string roomId, string htmlId, string html, bool isChanging)
+    {
+        var command = isChanging ? "changeprivateuhtml" : "sendprivateuhtml";
+        Bot.Say(roomId ?? RoomId, $"/{command} {userId}, {htmlId}, {html}");
+    }
 }

--- a/src/ElsaMina.Core/Resources/Resources.de-DE.resx
+++ b/src/ElsaMina.Core/Resources/Resources.de-DE.resx
@@ -1449,6 +1449,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>Das Voltorb-Flip-Spiel endete aufgrund von Inaktivität.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Bitte gib einen Raum an. Verwendung: -voltorbflip raumname</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>Der angegebene Raum wurde nicht gefunden oder der Bot ist nicht darin.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1502,6 +1508,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Spiel stoppen</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Nochmal spielen</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Setzt eine benutzerdefinierte Namensfarbe für einen Benutzer. Syntax: -setcolor &lt;Benutzer&gt;, &lt;#Hexfarbe&gt; (z. B. -setcolor Distrib, #9d6b15)</value>

--- a/src/ElsaMina.Core/Resources/Resources.en-US.resx
+++ b/src/ElsaMina.Core/Resources/Resources.en-US.resx
@@ -1449,6 +1449,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>The Voltorb Flip game ended due to inactivity.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Please specify a room. Usage: -voltorbflip roomname</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>The specified room was not found or the bot is not in it.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1502,6 +1508,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Stop game</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Play again</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Sets a custom name color for a user. Syntax: -setcolor &lt;user&gt;, &lt;#hexcolor&gt; (e.g. -setcolor Distrib, #9d6b15)</value>

--- a/src/ElsaMina.Core/Resources/Resources.es-ES.resx
+++ b/src/ElsaMina.Core/Resources/Resources.es-ES.resx
@@ -1454,6 +1454,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>La partida de Voltorb Flip terminó por inactividad.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Por favor especifica una sala. Uso: -voltorbflip nombresala</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>La sala especificada no fue encontrada o el bot no está en ella.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1507,6 +1513,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Detener partida</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Jugar de nuevo</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Establece un color de nombre personalizado para un usuario. Sintaxis: -setcolor &lt;usuario&gt;, &lt;#colorhex&gt; (ej: -setcolor Distrib, #9d6b15)</value>

--- a/src/ElsaMina.Core/Resources/Resources.fr-FR.resx
+++ b/src/ElsaMina.Core/Resources/Resources.fr-FR.resx
@@ -1449,6 +1449,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>La partie de Voltorb Flip s'est terminée par inactivité.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Veuillez spécifier une room. Utilisation : -voltorbflip nomdelaroom</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>La room spécifiée n'a pas été trouvée ou le bot n'y est pas présent.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1502,6 +1508,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Arrêter la partie</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Rejouer</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Définit une couleur de pseudo personnalisée pour un utilisateur. Syntaxe : -setcolor &lt;joueur&gt;, &lt;#hexcouleur&gt; (ex : -setcolor Distrib, #9d6b15)</value>

--- a/src/ElsaMina.Core/Resources/Resources.it-IT.resx
+++ b/src/ElsaMina.Core/Resources/Resources.it-IT.resx
@@ -1454,6 +1454,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>La partita di Voltorb Flip è terminata per inattività.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Specifica una stanza. Uso: -voltorbflip nomestanza</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>La stanza specificata non è stata trovata o il bot non è presente.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1507,6 +1513,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Ferma la partita</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Gioca ancora</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Imposta un colore personalizzato per il nickname di un utente. Sintassi: -setcolor &lt;utente&gt;, &lt;#coloreesadecimale&gt; (es. -setcolor Distrib, #9d6b15)</value>

--- a/src/ElsaMina.Core/Resources/Resources.pt-BR.resx
+++ b/src/ElsaMina.Core/Resources/Resources.pt-BR.resx
@@ -1449,6 +1449,12 @@
     <data name="vf_game_timeout" xml:space="preserve">
         <value>O jogo de Voltorb Flip terminou por inatividade.</value>
     </data>
+    <data name="vf_game_pm_missing_room" xml:space="preserve">
+        <value>Por favor, especifique uma sala. Uso: -voltorbflip nomedaSala</value>
+    </data>
+    <data name="vf_game_pm_invalid_room" xml:space="preserve">
+        <value>A sala especificada não foi encontrada ou o bot não está nela.</value>
+    </data>
     <data name="vf_panel_title" xml:space="preserve">
         <value>Voltorb Flip</value>
     </data>
@@ -1502,6 +1508,9 @@
     </data>
     <data name="vf_panel_stop" xml:space="preserve">
         <value>Parar jogo</value>
+    </data>
+    <data name="vf_panel_play_again" xml:space="preserve">
+        <value>Jogar novamente</value>
     </data>
     <data name="setcolor_help" xml:space="preserve">
         <value>Define uma cor de nome personalizada para um usuário. Sintaxe: -setcolor &lt;usuário&gt;, &lt;#hexcor&gt; (ex.: -setcolor Distrib, #9d6b15)</value>

--- a/test/ElsaMina.UnitTests/Commands/VoltorbFlip/EndVoltorbFlipCommandTest.cs
+++ b/test/ElsaMina.UnitTests/Commands/VoltorbFlip/EndVoltorbFlipCommandTest.cs
@@ -17,6 +17,8 @@ public class EndVoltorbFlipCommandTest
         public Rank Rank => Rank.Regular;
     }
 
+    private IRoomsManager _roomsManager;
+    private IVoltorbFlipGameManager _gameManager;
     private EndVoltorbFlipCommand _command;
     private IContext _context;
     private IRoom _room;
@@ -25,7 +27,9 @@ public class EndVoltorbFlipCommandTest
     [SetUp]
     public void SetUp()
     {
-        _command = new EndVoltorbFlipCommand();
+        _roomsManager = Substitute.For<IRoomsManager>();
+        _gameManager = Substitute.For<IVoltorbFlipGameManager>();
+        _command = new EndVoltorbFlipCommand(_roomsManager, _gameManager);
         _context = Substitute.For<IContext>();
         _room = Substitute.For<IRoom>();
         _voltorbFlipGame = Substitute.For<IVoltorbFlipGame>();

--- a/test/ElsaMina.UnitTests/Commands/VoltorbFlip/FlipVoltorbFlipCommandTest.cs
+++ b/test/ElsaMina.UnitTests/Commands/VoltorbFlip/FlipVoltorbFlipCommandTest.cs
@@ -9,6 +9,7 @@ namespace ElsaMina.UnitTests.Commands.VoltorbFlip;
 public class FlipVoltorbFlipCommandTest
 {
     private IRoomsManager _roomsManager;
+    private IVoltorbFlipGameManager _gameManager;
     private FlipVoltorbFlipCommand _command;
     private IContext _context;
     private IRoom _room;
@@ -19,7 +20,8 @@ public class FlipVoltorbFlipCommandTest
     public void SetUp()
     {
         _roomsManager = Substitute.For<IRoomsManager>();
-        _command = new FlipVoltorbFlipCommand(_roomsManager);
+        _gameManager = Substitute.For<IVoltorbFlipGameManager>();
+        _command = new FlipVoltorbFlipCommand(_roomsManager, _gameManager);
         _context = Substitute.For<IContext>();
         _room = Substitute.For<IRoom>();
         _voltorbFlipGame = Substitute.For<IVoltorbFlipGame>();
@@ -28,6 +30,7 @@ public class FlipVoltorbFlipCommandTest
         _context.Sender.Returns(_sender);
         _room.Game.Returns(_voltorbFlipGame);
         _roomsManager.GetRoom("test-room").Returns(_room);
+        _gameManager.GetGame(Arg.Any<string>(), Arg.Any<string>()).ReturnsNull();
     }
 
     [Test]

--- a/test/ElsaMina.UnitTests/Commands/VoltorbFlip/QuitVoltorbFlipCommandTest.cs
+++ b/test/ElsaMina.UnitTests/Commands/VoltorbFlip/QuitVoltorbFlipCommandTest.cs
@@ -9,6 +9,7 @@ namespace ElsaMina.UnitTests.Commands.VoltorbFlip;
 public class QuitVoltorbFlipCommandTest
 {
     private IRoomsManager _roomsManager;
+    private IVoltorbFlipGameManager _gameManager;
     private QuitVoltorbFlipCommand _command;
     private IContext _context;
     private IRoom _room;
@@ -19,7 +20,8 @@ public class QuitVoltorbFlipCommandTest
     public void SetUp()
     {
         _roomsManager = Substitute.For<IRoomsManager>();
-        _command = new QuitVoltorbFlipCommand(_roomsManager);
+        _gameManager = Substitute.For<IVoltorbFlipGameManager>();
+        _command = new QuitVoltorbFlipCommand(_roomsManager, _gameManager);
         _context = Substitute.For<IContext>();
         _room = Substitute.For<IRoom>();
         _voltorbFlipGame = Substitute.For<IVoltorbFlipGame>();
@@ -28,6 +30,7 @@ public class QuitVoltorbFlipCommandTest
         _context.Sender.Returns(_sender);
         _room.Game.Returns(_voltorbFlipGame);
         _roomsManager.GetRoom("test-room").Returns(_room);
+        _gameManager.GetGame(Arg.Any<string>(), Arg.Any<string>()).ReturnsNull();
     }
 
     [Test]

--- a/test/ElsaMina.UnitTests/Commands/VoltorbFlip/StartVoltorbFlipCommandTest.cs
+++ b/test/ElsaMina.UnitTests/Commands/VoltorbFlip/StartVoltorbFlipCommandTest.cs
@@ -14,6 +14,8 @@ namespace ElsaMina.UnitTests.Commands.VoltorbFlip;
 public class StartVoltorbFlipCommandTest
 {
     private IDependencyContainerService _dependencyContainerService;
+    private IRoomsManager _roomsManager;
+    private IVoltorbFlipGameManager _gameManager;
     private IConfiguration _configuration;
     private ITemplatesManager _templatesManager;
     private StartVoltorbFlipCommand _command;
@@ -25,9 +27,11 @@ public class StartVoltorbFlipCommandTest
     public void SetUp()
     {
         _dependencyContainerService = Substitute.For<IDependencyContainerService>();
+        _roomsManager = Substitute.For<IRoomsManager>();
+        _gameManager = Substitute.For<IVoltorbFlipGameManager>();
         _configuration = Substitute.For<IConfiguration>();
         _templatesManager = Substitute.For<ITemplatesManager>();
-        _command = new StartVoltorbFlipCommand(_dependencyContainerService);
+        _command = new StartVoltorbFlipCommand(_dependencyContainerService, _roomsManager, _gameManager);
 
         _context = Substitute.For<IContext>();
         _room = Substitute.For<IRoom>();

--- a/test/ElsaMina.UnitTests/Commands/VoltorbFlip/ToggleMarkVoltorbFlipCommandTest.cs
+++ b/test/ElsaMina.UnitTests/Commands/VoltorbFlip/ToggleMarkVoltorbFlipCommandTest.cs
@@ -9,6 +9,7 @@ namespace ElsaMina.UnitTests.Commands.VoltorbFlip;
 public class ToggleMarkVoltorbFlipCommandTest
 {
     private IRoomsManager _roomsManager;
+    private IVoltorbFlipGameManager _gameManager;
     private ToggleMarkVoltorbFlipCommand _command;
     private IContext _context;
     private IRoom _room;
@@ -19,7 +20,8 @@ public class ToggleMarkVoltorbFlipCommandTest
     public void SetUp()
     {
         _roomsManager = Substitute.For<IRoomsManager>();
-        _command = new ToggleMarkVoltorbFlipCommand(_roomsManager);
+        _gameManager = Substitute.For<IVoltorbFlipGameManager>();
+        _command = new ToggleMarkVoltorbFlipCommand(_roomsManager, _gameManager);
         _context = Substitute.For<IContext>();
         _room = Substitute.For<IRoom>();
         _voltorbFlipGame = Substitute.For<IVoltorbFlipGame>();
@@ -29,6 +31,7 @@ public class ToggleMarkVoltorbFlipCommandTest
         _context.Target.Returns("test-room");
         _room.Game.Returns(_voltorbFlipGame);
         _roomsManager.GetRoom("test-room").Returns(_room);
+        _gameManager.GetGame(Arg.Any<string>(), Arg.Any<string>()).ReturnsNull();
     }
 
     [Test]


### PR DESCRIPTION
Allow users to start VoltorbFlip from PM via `-voltorbflip <room>`, using /sendprivateuhtml and /changeprivateuhtml so non-staff users can play without needing room rank. The existing room-based flow remains unchanged.

- Add SendPrivateUpdatableHtml to IContext/RoomContext/PmContext
- Add VoltorbFlipGameManager for per-user private game storage
- Add private mode support to VoltorbFlipGame (IsPrivateMode, TargetRoomId, TargetUserId)
- Update interaction commands to check GameManager before room.Game fallback
- Add "Play again" button shown after round ends
- Add localization keys for PM error messages and play again (6 languages)
- Update tests for new constructor signatures