### PR TITLE
fix(say): guard against missing message argument

### DIFF
--- a/src/ElsaMina.Commands/Development/SayCommand.cs
+++ b/src/ElsaMina.Commands/Development/SayCommand.cs
@@ -19,7 +19,13 @@ public class SayCommand : DevelopmentCommand
 
     public override Task RunAsync(IContext context, CancellationToken cancellationToken = default)
     {
-        var parts = context.Target.Split(';');
+        var parts = context.Target.Split(';', 2);
+        if (parts.Length < 2)
+        {
+            context.Reply("Usage: say <roomId>;<message>");
+            return Task.CompletedTask;
+        }
+
         Log.Information("Say command used: {0}", context.Target);
         _bot.Say(parts[0], parts[1]);
         return Task.CompletedTask;


### PR DESCRIPTION
## Problème

`-say test` (sans `;`) plantait avec `IndexOutOfRangeException` : `context.Target.Split(';')` ne renvoyait qu'un élément et `parts[1]` était hors limites.

## Correctif

- `Split(';', 2)` pour ne découper que sur le premier `;` (un message contenant des `;` reste intact).
- Garde qui renvoie l'usage `say <roomId>;<message>` au lieu de crasher quand le format est incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)