### PR TITLE
fix(repeats): persist repeats so they survive bot restarts

### DIFF
--- a/src/ElsaMina.Commands/Repeats/StartRepeatCommand.cs
+++ b/src/ElsaMina.Commands/Repeats/StartRepeatCommand.cs
@@ -46,7 +46,8 @@ public class StartRepeatCommand : Command
             return;
         }
 
-        _repeatsManager.StartRepeat(context, roomId, message, TimeSpan.FromMinutes(delayInMinutes));
+        await _repeatsManager.StartRepeatAsync(roomId, message, TimeSpan.FromMinutes(delayInMinutes),
+            cancellationToken);
         context.ReplyLocalizedMessage("repeat_start_success");
     }
 }

--- a/src/ElsaMina.Commands/Repeats/StopRepeatCommand.cs
+++ b/src/ElsaMina.Commands/Repeats/StopRepeatCommand.cs
@@ -39,7 +39,7 @@ public class StopRepeatCommand : Command
             return;
         }
 
-        var ended = _repeatsManager.StopRepeat(guid);
+        var ended = await _repeatsManager.StopRepeatAsync(guid, cancellationToken);
         if (!ended)
         {
             context.ReplyLocalizedMessage("repeat_stop_error");

--- a/src/ElsaMina.Core/Services/Repeats/IRepeatsManager.cs
+++ b/src/ElsaMina.Core/Services/Repeats/IRepeatsManager.cs
@@ -1,11 +1,11 @@
-﻿using ElsaMina.Core.Contexts;
-
 namespace ElsaMina.Core.Services.Repeats;
 
 public interface IRepeatsManager
 {
-    void StartRepeat(IContext context, string roomId, string message, TimeSpan interval);
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+    Task StartRepeatAsync(string roomId, string message, TimeSpan interval,
+        CancellationToken cancellationToken = default);
     IRepeat GetRepeat(Guid repeatId);
     IEnumerable<IRepeat> GetRepeats(string roomId);
-    bool StopRepeat(Guid repeatId);
+    Task<bool> StopRepeatAsync(Guid repeatId, CancellationToken cancellationToken = default);
 }

--- a/src/ElsaMina.Core/Services/Repeats/Repeat.cs
+++ b/src/ElsaMina.Core/Services/Repeats/Repeat.cs
@@ -1,17 +1,17 @@
-﻿using System.Timers;
-using ElsaMina.Core.Contexts;
+using System.Timers;
+using ElsaMina.Logging;
 using Timer = System.Timers.Timer;
 
 namespace ElsaMina.Core.Services.Repeats;
 
 public sealed class Repeat : IRepeat
 {
-    private readonly IContext _context;
+    private readonly IBot _bot;
     private Timer _timer;
 
-    public Repeat(IContext context, Guid repeatId, string roomId, string message, TimeSpan interval)
+    public Repeat(IBot bot, Guid repeatId, string roomId, string message, TimeSpan interval)
     {
-        _context = context;
+        _bot = bot;
         RepeatId = repeatId;
         RoomId = roomId;
         Message = message;
@@ -51,7 +51,14 @@ public sealed class Repeat : IRepeat
 
     private void HandleTimerElapsed(object sender, ElapsedEventArgs e)
     {
-        var prefix = Message.StartsWith("/wall") || Message.StartsWith("/announce") ? string.Empty : "[[]]";
-        _context.SendMessageIn(RoomId, $"{prefix}{Message}");
+        try
+        {
+            var prefix = Message.StartsWith("/wall") || Message.StartsWith("/announce") ? string.Empty : "[[]]";
+            _bot.Say(RoomId, $"{prefix}{Message}");
+        }
+        catch (Exception exception)
+        {
+            Log.Error(exception, "Repeat {0} failed to send message in room {1}", RepeatId, RoomId);
+        }
     }
 }

--- a/src/ElsaMina.Core/Services/Repeats/RepeatsManager.cs
+++ b/src/ElsaMina.Core/Services/Repeats/RepeatsManager.cs
@@ -1,16 +1,48 @@
-﻿using ElsaMina.Core.Contexts;
+using ElsaMina.DataAccess;
+using ElsaMina.DataAccess.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace ElsaMina.Core.Services.Repeats;
 
 public class RepeatsManager : IRepeatsManager
 {
+    private readonly IBotDbContextFactory _dbContextFactory;
+    private readonly Lazy<IBot> _bot;
     private readonly Dictionary<Guid, Repeat> _repeats = new();
 
-    public void StartRepeat(IContext context, string roomId, string message, TimeSpan interval)
+    public RepeatsManager(IBotDbContextFactory dbContextFactory, Lazy<IBot> bot)
     {
-        var repeat = new Repeat(context, Guid.NewGuid(), roomId, message, interval);
-        _repeats[repeat.RepeatId] = repeat;
-        repeat.Start();
+        _dbContextFactory = dbContextFactory;
+        _bot = bot;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var savedRepeats = await dbContext.Repeats.ToListAsync(cancellationToken);
+        foreach (var savedRepeat in savedRepeats)
+        {
+            StartTimer(savedRepeat.Id, savedRepeat.RoomId, savedRepeat.Message, savedRepeat.Interval);
+        }
+    }
+
+    public async Task StartRepeatAsync(string roomId, string message, TimeSpan interval,
+        CancellationToken cancellationToken = default)
+    {
+        var repeatId = Guid.NewGuid();
+        await using (var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken))
+        {
+            dbContext.Repeats.Add(new SavedRepeat
+            {
+                Id = repeatId,
+                RoomId = roomId,
+                Message = message,
+                Interval = interval
+            });
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        StartTimer(repeatId, roomId, message, interval);
     }
 
     public IRepeat GetRepeat(Guid repeatId)
@@ -23,15 +55,27 @@ public class RepeatsManager : IRepeatsManager
         return _repeats.Values.Where(repeat => repeat.RoomId == roomId);
     }
 
-    public bool StopRepeat(Guid repeatId)
+    public async Task<bool> StopRepeatAsync(Guid repeatId, CancellationToken cancellationToken = default)
     {
-        if (!_repeats.TryGetValue(repeatId, out var repeat))
+        var stopped = _repeats.Remove(repeatId, out var repeat);
+        repeat?.Stop();
+
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var savedRepeat = await dbContext.Repeats.FindAsync([repeatId], cancellationToken);
+        if (savedRepeat != null)
         {
-            return false;
+            dbContext.Repeats.Remove(savedRepeat);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            stopped = true;
         }
 
-        repeat.Stop();
-        _repeats.Remove(repeatId);
-        return true;
+        return stopped;
+    }
+
+    private void StartTimer(Guid repeatId, string roomId, string message, TimeSpan interval)
+    {
+        var repeat = new Repeat(_bot.Value, repeatId, roomId, message, interval);
+        _repeats[repeatId] = repeat;
+        repeat.Start();
     }
 }

--- a/src/ElsaMina.Core/Services/Start/StartManager.cs
+++ b/src/ElsaMina.Core/Services/Start/StartManager.cs
@@ -1,6 +1,7 @@
 using ElsaMina.Core.Services.CustomColors;
 using ElsaMina.Core.Services.Dex;
 using ElsaMina.Core.Services.PlayTime;
+using ElsaMina.Core.Services.Repeats;
 using ElsaMina.Core.Services.Rooms;
 using ElsaMina.Core.Services.RoomUserData;
 using ElsaMina.Core.Services.Templates;
@@ -15,13 +16,15 @@ public class StartManager : IStartManager
     private readonly IRoomUserDataService _roomUserDataService;
     private readonly IDexManager _dexManager;
     private readonly IPlayTimeUpdateService _playTimeUpdateService;
+    private readonly IRepeatsManager _repeatsManager;
 
     public StartManager(ITemplatesManager templatesManager,
         ICustomColorsManager customColorsManager,
         IRoomColorsCache roomColorsCache,
         IRoomUserDataService roomUserDataService,
         IDexManager dexManager,
-        IPlayTimeUpdateService playTimeUpdateService)
+        IPlayTimeUpdateService playTimeUpdateService,
+        IRepeatsManager repeatsManager)
     {
         _templatesManager = templatesManager;
         _customColorsManager = customColorsManager;
@@ -29,6 +32,7 @@ public class StartManager : IStartManager
         _roomUserDataService = roomUserDataService;
         _dexManager = dexManager;
         _playTimeUpdateService = playTimeUpdateService;
+        _repeatsManager = repeatsManager;
     }
 
     public async Task LoadStaticDataAsync(CancellationToken cancellationToken = default)
@@ -39,7 +43,8 @@ public class StartManager : IStartManager
             _customColorsManager.FetchCustomColorsAsync(cancellationToken),
             _roomColorsCache.LoadAsync(cancellationToken),
             _roomUserDataService.InitializeJoinPhrasesAsync(cancellationToken),
-            _dexManager.LoadDexAsync(cancellationToken)
+            _dexManager.LoadDexAsync(cancellationToken),
+            _repeatsManager.InitializeAsync(cancellationToken)
         );
     }
 }

--- a/src/ElsaMina.DataAccess/BotDbContext.cs
+++ b/src/ElsaMina.DataAccess/BotDbContext.cs
@@ -47,6 +47,7 @@ public class BotDbContext : DbContext
     public DbSet<WordleScore> WordleScores { get; set; }
     public DbSet<WordEmbedding> WordEmbeddings { get; set; }
     public DbSet<SemantixScore> SemantixScores { get; set; }
+    public DbSet<SavedRepeat> Repeats { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/ElsaMina.DataAccess/Configurations/SavedRepeatConfiguration.cs
+++ b/src/ElsaMina.DataAccess/Configurations/SavedRepeatConfiguration.cs
@@ -1,0 +1,13 @@
+using ElsaMina.DataAccess.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace ElsaMina.DataAccess.Configurations;
+
+public class SavedRepeatConfiguration : IEntityTypeConfiguration<SavedRepeat>
+{
+    public void Configure(EntityTypeBuilder<SavedRepeat> builder)
+    {
+        builder.HasKey(repeat => repeat.Id);
+    }
+}

--- a/src/ElsaMina.DataAccess/Migrations/20260801193205_AddRepeatsTable.Designer.cs
+++ b/src/ElsaMina.DataAccess/Migrations/20260801193205_AddRepeatsTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ElsaMina.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ElsaMina.DataAccess.Migrations
 {
     [DbContext(typeof(BotDbContext))]
-    partial class BotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260801193205_AddRepeatsTable")]
+    partial class AddRepeatsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ElsaMina.DataAccess/Migrations/20260801193205_AddRepeatsTable.cs
+++ b/src/ElsaMina.DataAccess/Migrations/20260801193205_AddRepeatsTable.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ElsaMina.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepeatsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Repeats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    RoomId = table.Column<string>(type: "text", nullable: true),
+                    Message = table.Column<string>(type: "text", nullable: true),
+                    Interval = table.Column<TimeSpan>(type: "interval", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Repeats", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Repeats");
+        }
+    }
+}

--- a/src/ElsaMina.DataAccess/Models/SavedRepeat.cs
+++ b/src/ElsaMina.DataAccess/Models/SavedRepeat.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ElsaMina.DataAccess.Models;
+
+[Table("Repeats")]
+public class SavedRepeat
+{
+    public Guid Id { get; set; }
+    public string RoomId { get; set; }
+    public string Message { get; set; }
+    public TimeSpan Interval { get; set; }
+}

--- a/test/ElsaMina.UnitTests/Core/Services/Repeats/RepeatsManagerTest.cs
+++ b/test/ElsaMina.UnitTests/Core/Services/Repeats/RepeatsManagerTest.cs
@@ -1,0 +1,104 @@
+using ElsaMina.Core;
+using ElsaMina.Core.Services.Repeats;
+using ElsaMina.DataAccess;
+using ElsaMina.DataAccess.Models;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace ElsaMina.UnitTests.Core.Services.Repeats;
+
+public class RepeatsManagerTest
+{
+    private DbContextOptions<BotDbContext> _options;
+    private IBotDbContextFactory _factory;
+    private IBot _bot;
+    private RepeatsManager _manager;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _options = new DbContextOptionsBuilder<BotDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()) // isolate each test
+            .Options;
+
+        _factory = Substitute.For<IBotDbContextFactory>();
+        _factory.CreateDbContextAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new BotDbContext(_options)));
+
+        _bot = Substitute.For<IBot>();
+
+        _manager = new RepeatsManager(_factory, new Lazy<IBot>(() => _bot));
+    }
+
+    private async Task<int> CountRepeatsInDatabaseAsync()
+    {
+        await using var dbContext = new BotDbContext(_options);
+        return await dbContext.Repeats.CountAsync();
+    }
+
+    [Test]
+    public async Task Test_StartRepeatAsync_ShouldPersistRepeatAndTrackItInMemory_WhenCalled()
+    {
+        // Act
+        await _manager.StartRepeatAsync("testroom", "hello", TimeSpan.FromHours(1));
+
+        // Assert
+        var trackedRepeats = _manager.GetRepeats("testroom").ToList();
+        Assert.That(trackedRepeats, Has.Count.EqualTo(1));
+        Assert.That(trackedRepeats[0].Message, Is.EqualTo("hello"));
+        Assert.That(await CountRepeatsInDatabaseAsync(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Test_StopRepeatAsync_ShouldRemoveRepeatFromMemoryAndDatabase_WhenRepeatExists()
+    {
+        // Arrange
+        await _manager.StartRepeatAsync("testroom", "hello", TimeSpan.FromHours(1));
+        var repeatId = _manager.GetRepeats("testroom").Single().RepeatId;
+
+        // Act
+        var stopped = await _manager.StopRepeatAsync(repeatId);
+
+        // Assert
+        Assert.That(stopped, Is.True);
+        Assert.That(_manager.GetRepeat(repeatId), Is.Null);
+        Assert.That(await CountRepeatsInDatabaseAsync(), Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Test_StopRepeatAsync_ShouldReturnFalse_WhenRepeatDoesNotExist()
+    {
+        // Act
+        var stopped = await _manager.StopRepeatAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.That(stopped, Is.False);
+    }
+
+    [Test]
+    public async Task Test_InitializeAsync_ShouldReloadPersistedRepeatsAndStartThem_WhenCalled()
+    {
+        // Arrange
+        var repeatId = Guid.NewGuid();
+        await using (var dbContext = new BotDbContext(_options))
+        {
+            dbContext.Repeats.Add(new SavedRepeat
+            {
+                Id = repeatId,
+                RoomId = "testroom",
+                Message = "persisted",
+                Interval = TimeSpan.FromHours(1)
+            });
+            await dbContext.SaveChangesAsync();
+        }
+
+        // Act
+        await _manager.InitializeAsync();
+
+        // Assert
+        var reloaded = _manager.GetRepeat(repeatId);
+        Assert.That(reloaded, Is.Not.Null);
+        Assert.That(reloaded.RoomId, Is.EqualTo("testroom"));
+        Assert.That(reloaded.Message, Is.EqualTo("persisted"));
+    }
+}


### PR DESCRIPTION
## Problème

Les repeats n'étaient stockés que dans un dictionnaire en mémoire. Au moindre redémarrage du bot :
- les timers mouraient → plus aucun message ne s'affichait,
- le dictionnaire était vidé → `stoprepeat` répondait que l'id « n'existe pas ».

## Correctif

- **Nouvelle table `Repeats`** : modèle `SavedRepeat` + configuration + migration `AddRepeatsTable`.
- **`RepeatsManager`** persiste (`StartRepeatAsync`) et supprime (`StopRepeatAsync`) en base, et **recharge les repeats + relance les timers au démarrage** via `InitializeAsync` (branché dans `StartManager.LoadStaticDataAsync`).
- **`Repeat` découplé de `IContext`** → envoie via `IBot` directement (indispensable pour reconstruire un repeat au démarrage sans contexte vivant). La dépendance circulaire `Bot → StartManager → RepeatsManager → Bot` est cassée avec un `Lazy<IBot>`.
- **`try/catch` + log** dans le tick du timer pour éviter les échecs silencieux.
- **Tests unitaires** ajoutés sur le `RepeatsManager` (persistance, stop, reload).

## ⚠️ Déploiement

Nécessite d'appliquer la migration sur la base (`dotnet ef database update`) avant de redémarrer le bot, sinon la table `Repeats` n'existe pas.

## Vérifications

- Build solution OK, 4 tests repeats ✅, 489 tests d'intégration OK (le vrai conteneur Autofac monte → `Lazy<IBot>` résout bien le graphe DI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)